### PR TITLE
Add esp xtensa stackings to nuttx

### DIFF
--- a/src/rtos/Makefile.am
+++ b/src/rtos/Makefile.am
@@ -10,6 +10,7 @@ noinst_LTLIBRARIES += %D%/librtos.la
 	%D%/rtos_mqx_stackings.c \
 	%D%/rtos_ucos_iii_stackings.c \
 	%D%/rtos_riot_stackings.c \
+	%D%/rtos_nuttx_stackings.c \
 	%D%/FreeRTOS.c \
 	%D%/ThreadX.c \
 	%D%/eCos.c \
@@ -32,4 +33,5 @@ noinst_LTLIBRARIES += %D%/librtos.la
 	%D%/rtos_mqx_stackings.h \
 	%D%/rtos_riot_stackings.h \
 	%D%/rtos_ucos_iii_stackings.h \
+	%D%/rtos_nuttx_stackings.h \
 	%D%/nuttx_header.h

--- a/src/rtos/nuttx.c
+++ b/src/rtos/nuttx.c
@@ -21,7 +21,7 @@
 #include "server/gdb_server.h"
 
 #include "nuttx_header.h"
-
+#include "rtos_nuttx_stackings.h"
 
 int rtos_thread_packet(struct connection *connection, const char *packet, int packet_size);
 
@@ -83,62 +83,6 @@ static char *task_state_str[] = {
 #ifdef CONFIG_PAGING
 	"WAIT_PAGEFILL",
 #endif /* CONFIG_PAGING */
-};
-
-/* see arch/arm/include/armv7-m/irq_cmnvector.h */
-static const struct stack_register_offset nuttx_stack_offsets_cortex_m[] = {
-	{ ARMV7M_R0,	0x28, 32 },		/* r0   */
-	{ ARMV7M_R1,	0x2c, 32 },		/* r1   */
-	{ ARMV7M_R2,	0x30, 32 },		/* r2   */
-	{ ARMV7M_R3,	0x34, 32 },		/* r3   */
-	{ ARMV7M_R4,	0x08, 32 },		/* r4   */
-	{ ARMV7M_R5,	0x0c, 32 },		/* r5   */
-	{ ARMV7M_R6,	0x10, 32 },		/* r6   */
-	{ ARMV7M_R7,	0x14, 32 },		/* r7   */
-	{ ARMV7M_R8,	0x18, 32 },		/* r8   */
-	{ ARMV7M_R9,	0x1c, 32 },		/* r9   */
-	{ ARMV7M_R10,	0x20, 32 },		/* r10  */
-	{ ARMV7M_R11,	0x24, 32 },		/* r11  */
-	{ ARMV7M_R12,	0x38, 32 },		/* r12  */
-	{ ARMV7M_R13,	  0,  32 },		/* sp   */
-	{ ARMV7M_R14,	0x3c, 32 },		/* lr   */
-	{ ARMV7M_PC,	0x40, 32 },		/* pc   */
-	{ ARMV7M_XPSR,	0x44, 32 },		/* xPSR */
-};
-
-
-static const struct rtos_register_stacking nuttx_stacking_cortex_m = {
-	.stack_registers_size = 0x48,
-	.stack_growth_direction = -1,
-	.num_output_registers = 17,
-	.register_offsets = nuttx_stack_offsets_cortex_m
-};
-
-static const struct stack_register_offset nuttx_stack_offsets_cortex_m_fpu[] = {
-	{ ARMV7M_R0,	0x6c, 32 },		/* r0   */
-	{ ARMV7M_R1,	0x70, 32 },		/* r1   */
-	{ ARMV7M_R2,	0x74, 32 },		/* r2   */
-	{ ARMV7M_R3,	0x78, 32 },		/* r3   */
-	{ ARMV7M_R4,	0x08, 32 },		/* r4   */
-	{ ARMV7M_R5,	0x0c, 32 },		/* r5   */
-	{ ARMV7M_R6,	0x10, 32 },		/* r6   */
-	{ ARMV7M_R7,	0x14, 32 },		/* r7   */
-	{ ARMV7M_R8,	0x18, 32 },		/* r8   */
-	{ ARMV7M_R9,	0x1c, 32 },		/* r9   */
-	{ ARMV7M_R10,	0x20, 32 },		/* r10  */
-	{ ARMV7M_R11,	0x24, 32 },		/* r11  */
-	{ ARMV7M_R12,	0x7c, 32 },		/* r12  */
-	{ ARMV7M_R13,	  0,  32 },		/* sp   */
-	{ ARMV7M_R14,	0x80, 32 },		/* lr   */
-	{ ARMV7M_PC,	0x84, 32 },		/* pc   */
-	{ ARMV7M_XPSR,	0x88, 32 },		/* xPSR */
-};
-
-static const struct rtos_register_stacking nuttx_stacking_cortex_m_fpu = {
-	.stack_registers_size = 0x8c,
-	.stack_growth_direction = -1,
-	.num_output_registers = 17,
-	.register_offsets = nuttx_stack_offsets_cortex_m_fpu
 };
 
 static int pid_offset = PID;

--- a/src/rtos/nuttx.c
+++ b/src/rtos/nuttx.c
@@ -19,52 +19,57 @@
 #include "helper/log.h"
 #include "helper/types.h"
 #include "server/gdb_server.h"
-
-#include "nuttx_header.h"
+#include "target/register.h"
 #include "rtos_nuttx_stackings.h"
 
-int rtos_thread_packet(struct connection *connection, const char *packet, int packet_size);
+#define NAME_SIZE       32
+#define EXTRAINFO_SIZE  256
 
-#ifdef CONFIG_DISABLE_SIGNALS
-#define SIG_QUEUE_NUM 0
-#else
-#define SIG_QUEUE_NUM 1
-#endif /* CONFIG_DISABLE_SIGNALS */
+/* Only 32-bit CPUs are supported by the current implementation.  Supporting
+ * other CPUs will require reading this information from the target and
+ * adapting the code accordignly.
+ */
+#define PTR_WIDTH 4
 
-#ifdef CONFIG_DISABLE_MQUEUE
-#define M_QUEUE_NUM 0
-#else
-#define M_QUEUE_NUM 2
-#endif /* CONFIG_DISABLE_MQUEUE */
+static const struct rtos_register_stacking *cortexm_select_stackinfo(struct target *target);
+static const struct rtos_register_stacking *riscv_select_stackinfo(struct target *target);
 
-#ifdef CONFIG_PAGING
-#define PAGING_QUEUE_NUM 1
-#else
-#define PAGING_QUEUE_NUM 0
-#endif /* CONFIG_PAGING */
-
-
-#define TASK_QUEUE_NUM (6 + SIG_QUEUE_NUM + M_QUEUE_NUM + PAGING_QUEUE_NUM)
-
-
-/* see nuttx/sched/os_start.c */
-static char *nuttx_symbol_list[] = {
-	"g_readytorun",            /* 0: must be top of this array */
-	"g_tasklisttable",
-	NULL
+struct nuttx_params {
+	const char *target_name;
+	const struct rtos_register_stacking *(*select_stackinfo)(struct target *target);
 };
 
-/* see nuttx/include/nuttx/sched.h */
-struct tcb {
-	uint32_t flink;
-	uint32_t blink;
-	uint8_t  dat[512];
+struct tcbinfo {
+	uint8_t pid_off[2];
+	uint8_t state_off[2];
+	uint8_t pri_off[2];
+	uint8_t name_off[2];
+	uint8_t regs_off[2];
+	uint8_t basic_num[2];
+	uint8_t total_num[2];
+} __attribute__ ((packed));
+
+struct symbols {
+	const char *name;
+	bool optional;
 };
 
-static struct {
-	uint32_t addr;
-	uint32_t prio;
-} g_tasklist[TASK_QUEUE_NUM];
+/* Used to index the list of retrieved symbols. See nuttx_symbol_list for the order. */
+enum nuttx_symbol_vals {
+	NX_SYM_READYTORUN = 0,
+	NX_SYM_PIDHASH,
+	NX_SYM_NPIDHASH,
+	NX_SYM_TCB_INFO,
+};
+
+/* See nuttx/sched/nx_start.c */
+static const struct symbols nuttx_symbol_list[] = {
+	{ "g_readytorun", false },
+	{ "g_pidhash", false },
+	{ "g_npidhash", false },
+	{ "g_tcbinfo", false },
+	{ NULL, false }
+};
 
 static char *task_state_str[] = {
 	"INVALID",
@@ -73,259 +78,319 @@ static char *task_state_str[] = {
 	"RUNNING",
 	"INACTIVE",
 	"WAIT_SEM",
-#ifndef CONFIG_DISABLE_SIGNALS
 	"WAIT_SIG",
-#endif /* CONFIG_DISABLE_SIGNALS */
-#ifndef CONFIG_DISABLE_MQUEUE
 	"WAIT_MQNOTEMPTY",
 	"WAIT_MQNOTFULL",
-#endif /* CONFIG_DISABLE_MQUEUE */
-#ifdef CONFIG_PAGING
 	"WAIT_PAGEFILL",
-#endif /* CONFIG_PAGING */
+	"STOPPED",
 };
 
-static int pid_offset = PID;
-static int state_offset = STATE;
-static int name_offset =  NAME;
-static int xcpreg_offset = XCPREG;
-static int name_size = NAME_SIZE;
+static const struct nuttx_params nuttx_params_list[] = {
+	{
+		.target_name = "cortex_m",
+		.select_stackinfo = cortexm_select_stackinfo,
+	},
+	{
+		.target_name = "hla_target",
+		.select_stackinfo = cortexm_select_stackinfo,
+	},
+	{
+		.target_name = "esp32c3",
+		.select_stackinfo = riscv_select_stackinfo,
+	},
+};
 
-static int rcmd_offset(const char *cmd, const char *name)
+static bool cortexm_hasfpu(struct target *target)
 {
-	if (strncmp(cmd, name, strlen(name)))
-		return -1;
+	uint32_t cpacr;
+	struct armv7m_common *armv7m_target = target_to_armv7m(target);
 
-	if (strlen(cmd) <= strlen(name) + 1)
-		return -1;
+	if (!is_armv7m(armv7m_target) || armv7m_target->fp_feature != FPV4_SP)
+		return false;
 
-	return atoi(cmd + strlen(name));
-}
-
-static int nuttx_thread_packet(struct connection *connection,
-	char const *packet, int packet_size)
-{
-	char cmd[GDB_BUFFER_SIZE / 2 + 1] = ""; /* Extra byte for null-termination */
-
-	if (!strncmp(packet, "qRcmd", 5)) {
-		size_t len = unhexify((uint8_t *)cmd, packet + 6, sizeof(cmd));
-		int offset;
-
-		if (len <= 0)
-			goto pass;
-
-		offset = rcmd_offset(cmd, "nuttx.pid_offset");
-
-		if (offset >= 0) {
-			LOG_INFO("pid_offset: %d", offset);
-			pid_offset = offset;
-			goto retok;
-		}
-
-		offset = rcmd_offset(cmd, "nuttx.state_offset");
-
-		if (offset >= 0) {
-			LOG_INFO("state_offset: %d", offset);
-			state_offset = offset;
-			goto retok;
-		}
-
-		offset = rcmd_offset(cmd, "nuttx.name_offset");
-
-		if (offset >= 0) {
-			LOG_INFO("name_offset: %d", offset);
-			name_offset = offset;
-			goto retok;
-		}
-
-		offset = rcmd_offset(cmd, "nuttx.xcpreg_offset");
-
-		if (offset >= 0) {
-			LOG_INFO("xcpreg_offset: %d", offset);
-			xcpreg_offset = offset;
-			goto retok;
-		}
-
-		offset = rcmd_offset(cmd, "nuttx.name_size");
-
-		if (offset >= 0) {
-			LOG_INFO("name_size: %d", offset);
-			name_size = offset;
-			goto retok;
-		}
+	int retval = target_read_u32(target, FPU_CPACR, &cpacr);
+	if (retval != ERROR_OK) {
+		LOG_ERROR("Could not read CPACR register to check FPU state");
+		return false;
 	}
-pass:
-	return rtos_thread_packet(connection, packet, packet_size);
-retok:
-	gdb_put_packet(connection, "OK", 2);
-	return ERROR_OK;
+
+	return cpacr & 0x00F00000;
 }
 
+static const struct rtos_register_stacking *cortexm_select_stackinfo(struct target *target)
+{
+	return cortexm_hasfpu(target) ? &nuttx_stacking_cortex_m_fpu : &nuttx_stacking_cortex_m;
+}
+
+static const struct rtos_register_stacking *riscv_select_stackinfo(struct target *target)
+{
+	return &nuttx_riscv_stacking;
+}
 
 static bool nuttx_detect_rtos(struct target *target)
 {
 	if ((target->rtos->symbols) &&
-			(target->rtos->symbols[0].address != 0) &&
-			(target->rtos->symbols[1].address != 0)) {
+		(target->rtos->symbols[NX_SYM_READYTORUN].address != 0) &&
+		(target->rtos->symbols[NX_SYM_PIDHASH].address != 0))
 		return true;
-	}
 	return false;
 }
 
 static int nuttx_create(struct target *target)
 {
+	const struct nuttx_params *param;
+	unsigned int i;
 
-	target->rtos->gdb_thread_packet = nuttx_thread_packet;
-	LOG_INFO("target type name = %s", target->type->name);
-	return 0;
+	for (i = 0; i < ARRAY_SIZE(nuttx_params_list); i++) {
+		param = &nuttx_params_list[i];
+		if (strcmp(target_type_name(target), param->target_name) == 0) {
+			LOG_INFO("Detected target \"%s\"", param->target_name);
+			break;
+		}
+	}
+
+	if (i >= ARRAY_SIZE(nuttx_params_list)) {
+		LOG_ERROR("Could not find \"%s\" target in NuttX compatibility list",
+			target_type_name(target));
+		return JIM_ERR;
+	}
+
+	/* We found a target in our list, copy its reference. */
+	target->rtos->rtos_specific_params = (void *)param;
+
+	return JIM_OK;
 }
 
 static int nuttx_update_threads(struct rtos *rtos)
 {
-	uint32_t thread_count;
-	struct tcb tcb;
-	int ret;
-	uint32_t head;
-	uint32_t tcb_addr;
-	uint32_t i;
+	struct tcbinfo tcbinfo;
+	uint32_t thread_count, pidhashaddr, npidhash, tcbaddr;
+	uint16_t pid;
 	uint8_t state;
 
 	if (!rtos->symbols) {
 		LOG_ERROR("No symbols for NuttX");
-		return -3;
-	}
-
-	/* free previous thread details */
-	rtos_free_threadlist(rtos);
-
-	ret = target_read_buffer(rtos->target, rtos->symbols[1].address,
-		sizeof(g_tasklist), (uint8_t *)&g_tasklist);
-	if (ret) {
-		LOG_ERROR("target_read_buffer : ret = %d\n", ret);
 		return ERROR_FAIL;
 	}
 
+	/* Free previous thread details */
+	rtos_free_threadlist(rtos);
+
+	/* NuttX provides a hash table that keeps track of all the TCBs.
+	 * We first read its size from g_npidhash and its address from g_pidhash.
+	 * Its content is then read from these values.
+	 */
+	int ret = target_read_u32(rtos->target, rtos->symbols[NX_SYM_NPIDHASH].address, &npidhash);
+	if (ret != ERROR_OK) {
+		LOG_ERROR("Failed to read g_npidhash: ret = %d", ret);
+		return ERROR_FAIL;
+	}
+
+	LOG_DEBUG("Hash table size (g_npidhash) = %" PRId32, npidhash);
+
+	ret = target_read_u32(rtos->target, rtos->symbols[NX_SYM_PIDHASH].address, &pidhashaddr);
+	if (ret != ERROR_OK) {
+		LOG_ERROR("Failed to read g_pidhash address: ret = %d", ret);
+		return ERROR_FAIL;
+	}
+
+	LOG_DEBUG("Hash table address (g_pidhash) = %" PRIx32, pidhashaddr);
+
+	uint8_t *pidhash = malloc(npidhash * PTR_WIDTH);
+	if (!pidhash) {
+		LOG_ERROR("Failed to allocate pidhash");
+		return ERROR_FAIL;
+	}
+
+	ret = target_read_buffer(rtos->target, pidhashaddr, PTR_WIDTH * npidhash, pidhash);
+	if (ret != ERROR_OK) {
+		LOG_ERROR("Failed to read tcbhash: ret = %d", ret);
+		goto errout;
+	}
+
+	/* NuttX provides a struct that contains TCB offsets for required members.
+	 * Read its content from g_tcbinfo.
+	 */
+	ret = target_read_buffer(rtos->target, rtos->symbols[NX_SYM_TCB_INFO].address,
+		sizeof(tcbinfo), (uint8_t *)&tcbinfo);
+	if (ret != ERROR_OK) {
+		LOG_ERROR("Failed to read tcbinfo: ret = %d", ret);
+		goto errout;
+	}
+
+	/* The head of the g_readytorun list is the currently running task.
+	 * Reading in a temporary variable first to avoid endianness issues,
+	 * rtos->current_thread is int64_t. */
+	uint32_t current_thread;
+	ret = target_read_u32(rtos->target, rtos->symbols[NX_SYM_READYTORUN].address, &current_thread);
+	if (ret != ERROR_OK) {
+		LOG_ERROR("Failed to read g_readytorun: ret = %d", ret);
+		goto errout;
+	}
+	rtos->current_thread = current_thread;
+
 	thread_count = 0;
 
-	for (i = 0; i < TASK_QUEUE_NUM; i++) {
+	for (unsigned int i = 0; i < npidhash; i++) {
+		tcbaddr = le_to_h_u32(&pidhash[i * sizeof(uint32_t)]);
 
-		if (g_tasklist[i].addr == 0)
-			continue;
-
-		ret = target_read_u32(rtos->target, g_tasklist[i].addr,
-			&head);
-
-		if (ret) {
-			LOG_ERROR("target_read_u32 : ret = %d\n", ret);
-			return ERROR_FAIL;
-		}
-
-		/* readytorun head is current thread */
-		if (g_tasklist[i].addr == rtos->symbols[0].address)
-			rtos->current_thread = head;
-
-
-		tcb_addr = head;
-		while (tcb_addr) {
+		if (tcbaddr) {
 			struct thread_detail *thread;
-			ret = target_read_buffer(rtos->target, tcb_addr,
-				sizeof(tcb), (uint8_t *)&tcb);
-			if (ret) {
-				LOG_ERROR("target_read_buffer : ret = %d\n",
-					ret);
-				return ERROR_FAIL;
+
+			ret = target_read_u16(rtos->target, tcbaddr + le_to_h_u16(tcbinfo.pid_off), &pid);
+			if (ret != ERROR_OK) {
+				LOG_ERROR("Failed to read PID of TCB@0x%x from pidhash[%d]: ret = %d",
+					tcbaddr, i, ret);
+				goto errout;
 			}
+
+			ret = target_read_u8(rtos->target, tcbaddr + le_to_h_u16(tcbinfo.state_off), &state);
+			if (ret != ERROR_OK) {
+				LOG_ERROR("Failed to read state of TCB@0x%x from pidhash[%d]: ret = %d",
+					tcbaddr, i, ret);
+				goto errout;
+			}
+
 			thread_count++;
 
 			rtos->thread_details = realloc(rtos->thread_details,
 				sizeof(struct thread_detail) * thread_count);
+			if (!rtos->thread_details) {
+				ret = ERROR_FAIL;
+				goto errout;
+			}
+
 			thread = &rtos->thread_details[thread_count - 1];
-			thread->threadid = tcb_addr;
+			thread->threadid = tcbaddr;
 			thread->exists = true;
 
-			state = tcb.dat[state_offset - 8];
 			thread->extra_info_str = NULL;
 			if (state < ARRAY_SIZE(task_state_str)) {
-				thread->extra_info_str = malloc(256);
-				snprintf(thread->extra_info_str, 256, "pid:%d, %s",
-				    tcb.dat[pid_offset - 8] |
-				    tcb.dat[pid_offset - 8 + 1] << 8,
-				    task_state_str[state]);
+				thread->extra_info_str = malloc(EXTRAINFO_SIZE);
+				if (!thread->extra_info_str) {
+					ret = ERROR_FAIL;
+					goto errout;
+				}
+				snprintf(thread->extra_info_str, EXTRAINFO_SIZE, "pid:%d, %s",
+					pid,
+					task_state_str[state]);
 			}
 
-			if (name_offset) {
-				thread->thread_name_str = malloc(name_size + 1);
-				snprintf(thread->thread_name_str, name_size,
-				    "%s", (char *)&tcb.dat[name_offset - 8]);
+			if (le_to_h_u16(tcbinfo.name_off)) {
+				thread->thread_name_str = calloc(NAME_SIZE + 1, sizeof(char));
+				if (!thread->thread_name_str) {
+					ret = ERROR_FAIL;
+					goto errout;
+				}
+				ret = target_read_buffer(rtos->target, tcbaddr + le_to_h_u16(tcbinfo.name_off),
+					sizeof(char) * NAME_SIZE, (uint8_t *)thread->thread_name_str);
+				if (ret != ERROR_OK) {
+					LOG_ERROR("Failed to read thread's name: ret = %d", ret);
+					goto errout;
+				}
 			} else {
-				thread->thread_name_str = malloc(sizeof("None"));
-				strcpy(thread->thread_name_str, "None");
+				thread->thread_name_str = strdup("None");
 			}
-
-			tcb_addr = tcb.flink;
 		}
 	}
-	rtos->thread_count = thread_count;
 
-	return 0;
+	ret = ERROR_OK;
+	rtos->thread_count = thread_count;
+errout:
+	free(pidhash);
+	return ret;
 }
 
+static int nuttx_getreg_current_thread(struct rtos *rtos,
+	struct rtos_reg **reg_list, int *num_regs)
+{
+	struct reg **gdb_reg_list;
 
-/*
- * thread_id = tcb address;
- */
+	/* Registers for currently running thread are not on task's stack and
+	 * should be retrieved from reg caches via target_get_gdb_reg_list */
+	int ret = target_get_gdb_reg_list(rtos->target, &gdb_reg_list, num_regs,
+		REG_CLASS_GENERAL);
+	if (ret != ERROR_OK) {
+		LOG_ERROR("target_get_gdb_reg_list failed %d", ret);
+		return ret;
+	}
+
+	*reg_list = calloc(*num_regs, sizeof(struct rtos_reg));
+	if (!(*reg_list)) {
+		LOG_ERROR("Failed to alloc memory for %d", *num_regs);
+		free(gdb_reg_list);
+		return ERROR_FAIL;
+	}
+
+	for (int i = 0; i < *num_regs; i++) {
+		(*reg_list)[i].number = gdb_reg_list[i]->number;
+		(*reg_list)[i].size = gdb_reg_list[i]->size;
+		memcpy((*reg_list)[i].value, gdb_reg_list[i]->value, ((*reg_list)[i].size + 7) / 8);
+	}
+
+	free(gdb_reg_list);
+
+	return ERROR_OK;
+}
+
+static int nuttx_getregs_fromstack(struct rtos *rtos, int64_t thread_id,
+	struct rtos_reg **reg_list, int *num_regs)
+{
+	const struct rtos_register_stacking *stacking;
+	uint16_t xcpreg_off;
+	uint32_t regsaddr;
+	const struct nuttx_params *priv = (const struct nuttx_params *)rtos->rtos_specific_params;
+
+	if (priv->select_stackinfo) {
+		stacking = priv->select_stackinfo(rtos->target);
+	} else {
+		LOG_ERROR("Can't find a way to select stacking info");
+		return ERROR_FAIL;
+	}
+
+	int ret = target_read_u16(rtos->target,
+		rtos->symbols[NX_SYM_TCB_INFO].address + offsetof(struct tcbinfo, regs_off),
+		&xcpreg_off);
+	if (ret != ERROR_OK) {
+		LOG_ERROR("Failed to read registers' offset: ret = %d", ret);
+		return ERROR_FAIL;
+	}
+
+	ret = target_read_u32(rtos->target, thread_id + xcpreg_off, &regsaddr);
+	if (ret != ERROR_OK) {
+		LOG_ERROR("Failed to read registers' address: ret = %d", ret);
+		return ERROR_FAIL;
+	}
+
+	return rtos_generic_stack_read(rtos->target, stacking, regsaddr, reg_list, num_regs);
+}
+
 static int nuttx_get_thread_reg_list(struct rtos *rtos, int64_t thread_id,
 	struct rtos_reg **reg_list, int *num_regs)
 {
-	int retval;
+	if (!rtos)
+		return ERROR_FAIL;
 
-	/* Check for armv7m with *enabled* FPU, i.e. a Cortex-M4F */
-	bool cm4_fpu_enabled = false;
-	struct armv7m_common *armv7m_target = target_to_armv7m(rtos->target);
-	if (is_armv7m(armv7m_target)) {
-		if (armv7m_target->fp_feature == FPV4_SP) {
-			/* Found ARM v7m target which includes a FPU */
-			uint32_t cpacr;
-
-			retval = target_read_u32(rtos->target, FPU_CPACR, &cpacr);
-			if (retval != ERROR_OK) {
-				LOG_ERROR("Could not read CPACR register to check FPU state");
-				return -1;
-			}
-
-			/* Check if CP10 and CP11 are set to full access. */
-			if (cpacr & 0x00F00000) {
-				/* Found target with enabled FPU */
-				cm4_fpu_enabled = 1;
-			}
-		}
-	}
-
-	const struct rtos_register_stacking *stacking;
-	if (cm4_fpu_enabled)
-		stacking = &nuttx_stacking_cortex_m_fpu;
-	else
-		stacking = &nuttx_stacking_cortex_m;
-
-	return rtos_generic_stack_read(rtos->target, stacking,
-	    (uint32_t)thread_id + xcpreg_offset, reg_list, num_regs);
+	if (thread_id == rtos->current_thread)
+		return nuttx_getreg_current_thread(rtos, reg_list, num_regs);
+	return nuttx_getregs_fromstack(rtos, thread_id, reg_list, num_regs);
 }
 
 static int nuttx_get_symbol_list_to_lookup(struct symbol_table_elem *symbol_list[])
 {
-	unsigned int i;
-
-	*symbol_list = (struct symbol_table_elem *) calloc(1,
+	*symbol_list = (struct symbol_table_elem *)calloc(1,
 		sizeof(struct symbol_table_elem) * ARRAY_SIZE(nuttx_symbol_list));
 
-	for (i = 0; i < ARRAY_SIZE(nuttx_symbol_list); i++)
-		(*symbol_list)[i].symbol_name = nuttx_symbol_list[i];
+	for (unsigned int i = 0; i < ARRAY_SIZE(nuttx_symbol_list); i++) {
+		(*symbol_list)[i].symbol_name = nuttx_symbol_list[i].name;
+		(*symbol_list)[i].optional = nuttx_symbol_list[i].optional;
+	}
 
-	return 0;
+	return ERROR_OK;
 }
 
 struct rtos_type nuttx_rtos = {
-	.name = "nuttx",
+	.name = "NuttX",
 	.detect_rtos = nuttx_detect_rtos,
 	.create = nuttx_create,
 	.update_threads = nuttx_update_threads,

--- a/src/rtos/nuttx.c
+++ b/src/rtos/nuttx.c
@@ -108,7 +108,6 @@ static const struct nuttx_params nuttx_params_list[] = {
 		.target_name = "esp32s3",
 		.select_stackinfo = esp32s3_select_stackinfo,
 	},
-
 };
 
 static bool cortexm_hasfpu(struct target *target)
@@ -146,11 +145,6 @@ static const struct rtos_register_stacking *esp32s2_select_stackinfo(struct targ
 static const struct rtos_register_stacking *esp32s3_select_stackinfo(struct target *target)
 {
 	return &nuttx_esp32s3_stacking;
-}
-
-static const struct rtos_register_stacking *riscv_select_stackinfo(struct target *target)
-{
-	return &nuttx_riscv_stacking;
 }
 
 static bool nuttx_detect_rtos(struct target *target)

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -630,9 +630,15 @@ int rtos_generic_stack_read(struct target *target,
 	uint8_t *stack_data = malloc(stacking->stack_registers_size);
 	uint32_t address = stack_ptr;
 
-	if (stacking->stack_growth_direction == 1)
-		address -= stacking->stack_registers_size;
-	retval = target_read_buffer(target, address, stacking->stack_registers_size, stack_data);
+	if (stacking->custom_stack_read_fn) {
+		retval = stacking->custom_stack_read_fn(target, stack_ptr, stacking, stack_data);
+	} else {
+		if (stacking->stack_growth_direction == 1)
+			address -= stacking->stack_registers_size;
+		retval = target_read_buffer(target, address, stacking->stack_registers_size, stack_data);
+	}
+
+
 	if (retval != ERROR_OK) {
 		free(stack_data);
 		LOG_ERROR("Error reading stack frame from thread");

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -102,6 +102,12 @@ struct rtos_register_stacking {
 		const struct rtos_register_stacking *stacking,
 		target_addr_t stack_ptr);
 	const struct stack_register_offset *register_offsets;
+	/* Some targets have to implement their own stack read function,
+	 * because the stack is formatted weird or needs mangling before
+	 * passing it on to gdb.
+	 */
+	int (*custom_stack_read_fn)(struct target *target,
+		int64_t stack_ptr, const struct rtos_register_stacking *stacking, uint8_t *stack_data);
 };
 
 #define GDB_THREAD_PACKET_NOT_CONSUMED (-40)

--- a/src/rtos/rtos_nuttx_stackings.c
+++ b/src/rtos/rtos_nuttx_stackings.c
@@ -9,7 +9,9 @@
 #endif
 
 #include "rtos.h"
+#include "rtos_standard_stackings.h"
 #include "target/armv7m.h"
+#include <target/riscv/riscv.h>
 
 /* see arch/arm/include/armv7-m/irq_cmnvector.h */
 static const struct stack_register_offset nuttx_stack_offsets_cortex_m[] = {
@@ -64,4 +66,48 @@ const struct rtos_register_stacking nuttx_stacking_cortex_m_fpu = {
 	.stack_growth_direction = -1,
 	.num_output_registers = 17,
 	.register_offsets = nuttx_stack_offsets_cortex_m_fpu,
+};
+
+static const struct stack_register_offset nuttx_stack_offsets_riscv[] = {
+	{ GDB_REGNO_ZERO, -1, 32 },
+	{ GDB_REGNO_RA, 0x04, 32 },
+	{ GDB_REGNO_SP, 0x08, 32 },
+	{ GDB_REGNO_GP, 0x0c, 32 },
+	{ GDB_REGNO_TP, 0x10, 32 },
+	{ GDB_REGNO_T0, 0x14, 32 },
+	{ GDB_REGNO_T1, 0x18, 32 },
+	{ GDB_REGNO_T2, 0x1c, 32 },
+	{ GDB_REGNO_FP, 0x20, 32 },
+	{ GDB_REGNO_S1, 0x24, 32 },
+	{ GDB_REGNO_A0, 0x28, 32 },
+	{ GDB_REGNO_A1, 0x2c, 32 },
+	{ GDB_REGNO_A2, 0x30, 32 },
+	{ GDB_REGNO_A3, 0x34, 32 },
+	{ GDB_REGNO_A4, 0x38, 32 },
+	{ GDB_REGNO_A5, 0x3c, 32 },
+	{ GDB_REGNO_A6, 0x40, 32 },
+	{ GDB_REGNO_A7, 0x44, 32 },
+	{ GDB_REGNO_S2, 0x48, 32 },
+	{ GDB_REGNO_S3, 0x4c, 32 },
+	{ GDB_REGNO_S4, 0x50, 32 },
+	{ GDB_REGNO_S5, 0x54, 32 },
+	{ GDB_REGNO_S6, 0x58, 32 },
+	{ GDB_REGNO_S7, 0x5c, 32 },
+	{ GDB_REGNO_S8, 0x60, 32 },
+	{ GDB_REGNO_S9, 0x64, 32 },
+	{ GDB_REGNO_S10, 0x68, 32 },
+	{ GDB_REGNO_S11, 0x6c, 32 },
+	{ GDB_REGNO_T3, 0x70, 32 },
+	{ GDB_REGNO_T4, 0x74, 32 },
+	{ GDB_REGNO_T5, 0x78, 32 },
+	{ GDB_REGNO_T6, 0x7c, 32 },
+	{ GDB_REGNO_PC, 0x00, 32 },
+};
+
+const struct rtos_register_stacking nuttx_riscv_stacking = {
+	.stack_registers_size = 33 * 4,
+	.stack_growth_direction = -1,
+	.num_output_registers = 33,
+	.calculate_process_stack = rtos_generic_stack_align8,
+	.register_offsets = nuttx_stack_offsets_riscv,
 };

--- a/src/rtos/rtos_nuttx_stackings.c
+++ b/src/rtos/rtos_nuttx_stackings.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/***************************************************************************
+ *   Copyright (C) 2020 Espressif Systems Ltd.                             *
+ ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "rtos.h"
+#include "target/armv7m.h"
+
+/* see arch/arm/include/armv7-m/irq_cmnvector.h */
+static const struct stack_register_offset nuttx_stack_offsets_cortex_m[] = {
+	{ ARMV7M_R0, 0x28, 32 },		/* r0   */
+	{ ARMV7M_R1, 0x2c, 32 },		/* r1   */
+	{ ARMV7M_R2, 0x30, 32 },		/* r2   */
+	{ ARMV7M_R3, 0x34, 32 },		/* r3   */
+	{ ARMV7M_R4, 0x08, 32 },		/* r4   */
+	{ ARMV7M_R5, 0x0c, 32 },		/* r5   */
+	{ ARMV7M_R6, 0x10, 32 },		/* r6   */
+	{ ARMV7M_R7, 0x14, 32 },		/* r7   */
+	{ ARMV7M_R8, 0x18, 32 },		/* r8   */
+	{ ARMV7M_R9, 0x1c, 32 },		/* r9   */
+	{ ARMV7M_R10, 0x20, 32 },		/* r10  */
+	{ ARMV7M_R11, 0x24, 32 },		/* r11  */
+	{ ARMV7M_R12, 0x38, 32 },		/* r12  */
+	{ ARMV7M_R13, 0, 32 },			/* sp   */
+	{ ARMV7M_R14, 0x3c, 32 },		/* lr   */
+	{ ARMV7M_PC, 0x40, 32 },		/* pc   */
+	{ ARMV7M_XPSR, 0x44, 32 },		/* xPSR */
+};
+
+const struct rtos_register_stacking nuttx_stacking_cortex_m = {
+	.stack_registers_size = 0x48,
+	.stack_growth_direction = -1,
+	.num_output_registers = 17,
+	.register_offsets = nuttx_stack_offsets_cortex_m,
+};
+
+static const struct stack_register_offset nuttx_stack_offsets_cortex_m_fpu[] = {
+	{ ARMV7M_R0, 0x6c, 32 },		/* r0   */
+	{ ARMV7M_R1, 0x70, 32 },		/* r1   */
+	{ ARMV7M_R2, 0x74, 32 },		/* r2   */
+	{ ARMV7M_R3, 0x78, 32 },		/* r3   */
+	{ ARMV7M_R4, 0x08, 32 },		/* r4   */
+	{ ARMV7M_R5, 0x0c, 32 },		/* r5   */
+	{ ARMV7M_R6, 0x10, 32 },		/* r6   */
+	{ ARMV7M_R7, 0x14, 32 },		/* r7   */
+	{ ARMV7M_R8, 0x18, 32 },		/* r8   */
+	{ ARMV7M_R9, 0x1c, 32 },		/* r9   */
+	{ ARMV7M_R10, 0x20, 32 },		/* r10  */
+	{ ARMV7M_R11, 0x24, 32 },		/* r11  */
+	{ ARMV7M_R12, 0x7c, 32 },		/* r12  */
+	{ ARMV7M_R13, 0, 32 },			/* sp   */
+	{ ARMV7M_R14, 0x80, 32 },		/* lr   */
+	{ ARMV7M_PC, 0x84, 32 },		/* pc   */
+	{ ARMV7M_XPSR, 0x88, 32 },		/* xPSR */
+};
+
+const struct rtos_register_stacking nuttx_stacking_cortex_m_fpu = {
+	.stack_registers_size = 0x8c,
+	.stack_growth_direction = -1,
+	.num_output_registers = 17,
+	.register_offsets = nuttx_stack_offsets_cortex_m_fpu,
+};

--- a/src/rtos/rtos_nuttx_stackings.c
+++ b/src/rtos/rtos_nuttx_stackings.c
@@ -10,8 +10,14 @@
 
 #include "rtos.h"
 #include "rtos_standard_stackings.h"
+#include "target/target.h"
+#include "helper/log.h"
+#include "helper/binarybuffer.h"
 #include "target/armv7m.h"
-#include <target/riscv/riscv.h>
+
+static int nuttx_esp_xtensa_stack_read(struct target *target,
+	int64_t stack_ptr, const struct rtos_register_stacking *stacking,
+	uint8_t *stack_data);
 
 /* see arch/arm/include/armv7-m/irq_cmnvector.h */
 static const struct stack_register_offset nuttx_stack_offsets_cortex_m[] = {
@@ -68,46 +74,361 @@ const struct rtos_register_stacking nuttx_stacking_cortex_m_fpu = {
 	.register_offsets = nuttx_stack_offsets_cortex_m_fpu,
 };
 
-static const struct stack_register_offset nuttx_stack_offsets_riscv[] = {
-	{ GDB_REGNO_ZERO, -1, 32 },
-	{ GDB_REGNO_RA, 0x04, 32 },
-	{ GDB_REGNO_SP, 0x08, 32 },
-	{ GDB_REGNO_GP, 0x0c, 32 },
-	{ GDB_REGNO_TP, 0x10, 32 },
-	{ GDB_REGNO_T0, 0x14, 32 },
-	{ GDB_REGNO_T1, 0x18, 32 },
-	{ GDB_REGNO_T2, 0x1c, 32 },
-	{ GDB_REGNO_FP, 0x20, 32 },
-	{ GDB_REGNO_S1, 0x24, 32 },
-	{ GDB_REGNO_A0, 0x28, 32 },
-	{ GDB_REGNO_A1, 0x2c, 32 },
-	{ GDB_REGNO_A2, 0x30, 32 },
-	{ GDB_REGNO_A3, 0x34, 32 },
-	{ GDB_REGNO_A4, 0x38, 32 },
-	{ GDB_REGNO_A5, 0x3c, 32 },
-	{ GDB_REGNO_A6, 0x40, 32 },
-	{ GDB_REGNO_A7, 0x44, 32 },
-	{ GDB_REGNO_S2, 0x48, 32 },
-	{ GDB_REGNO_S3, 0x4c, 32 },
-	{ GDB_REGNO_S4, 0x50, 32 },
-	{ GDB_REGNO_S5, 0x54, 32 },
-	{ GDB_REGNO_S6, 0x58, 32 },
-	{ GDB_REGNO_S7, 0x5c, 32 },
-	{ GDB_REGNO_S8, 0x60, 32 },
-	{ GDB_REGNO_S9, 0x64, 32 },
-	{ GDB_REGNO_S10, 0x68, 32 },
-	{ GDB_REGNO_S11, 0x6c, 32 },
-	{ GDB_REGNO_T3, 0x70, 32 },
-	{ GDB_REGNO_T4, 0x74, 32 },
-	{ GDB_REGNO_T5, 0x78, 32 },
-	{ GDB_REGNO_T6, 0x7c, 32 },
-	{ GDB_REGNO_PC, 0x00, 32 },
+static const struct stack_register_offset nuttx_stack_offsets_esp32[] = {
+	{ 0, 0x00, 32 },		/* PC */
+	{ 1, 0x08, 32 },		/* A0 */
+	{ 2, 0x0c, 32 },		/* A1 */
+	{ 3, 0x10, 32 },		/* A2 */
+	{ 4, 0x14, 32 },		/* A3 */
+	{ 5, 0x18, 32 },		/* A4 */
+	{ 6, 0x1c, 32 },		/* A5 */
+	{ 7, 0x20, 32 },		/* A6 */
+	{ 8, 0x24, 32 },		/* A7 */
+	{ 9, 0x28, 32 },		/* A8 */
+	{ 10, 0x2c, 32 },		/* A9 */
+	{ 11, 0x30, 32 },		/* A10 */
+	{ 12, 0x34, 32 },		/* A11 */
+	{ 13, 0x38, 32 },		/* A12 */
+	{ 14, 0x3c, 32 },		/* A13 */
+	{ 15, 0x40, 32 },		/* A14 */
+	{ 16, 0x44, 32 },		/* A15 */
+	/* A16-A63 aren't in the stack frame because they've been flushed to the stack earlier */
+	{ 17, -1, 32 },			/* A16 */
+	{ 18, -1, 32 },			/* A17 */
+	{ 19, -1, 32 },			/* A18 */
+	{ 20, -1, 32 },			/* A19 */
+	{ 21, -1, 32 },			/* A20 */
+	{ 22, -1, 32 },			/* A21 */
+	{ 23, -1, 32 },			/* A22 */
+	{ 24, -1, 32 },			/* A23 */
+	{ 25, -1, 32 },			/* A24 */
+	{ 26, -1, 32 },			/* A25 */
+	{ 27, -1, 32 },			/* A26 */
+	{ 28, -1, 32 },			/* A27 */
+	{ 29, -1, 32 },			/* A28 */
+	{ 30, -1, 32 },			/* A29 */
+	{ 31, -1, 32 },			/* A30 */
+	{ 32, -1, 32 },			/* A31 */
+	{ 33, -1, 32 },			/* A32 */
+	{ 34, -1, 32 },			/* A33 */
+	{ 35, -1, 32 },			/* A34 */
+	{ 36, -1, 32 },			/* A35 */
+	{ 37, -1, 32 },			/* A36 */
+	{ 38, -1, 32 },			/* A37 */
+	{ 39, -1, 32 },			/* A38 */
+	{ 40, -1, 32 },			/* A39 */
+	{ 41, -1, 32 },			/* A40 */
+	{ 42, -1, 32 },			/* A41 */
+	{ 43, -1, 32 },			/* A42 */
+	{ 44, -1, 32 },			/* A43 */
+	{ 45, -1, 32 },			/* A44 */
+	{ 46, -1, 32 },			/* A45 */
+	{ 47, -1, 32 },			/* A46 */
+	{ 48, -1, 32 },			/* A47 */
+	{ 49, -1, 32 },			/* A48 */
+	{ 50, -1, 32 },			/* A49 */
+	{ 51, -1, 32 },			/* A50 */
+	{ 52, -1, 32 },			/* A51 */
+	{ 53, -1, 32 },			/* A52 */
+	{ 54, -1, 32 },			/* A53 */
+	{ 55, -1, 32 },			/* A54 */
+	{ 56, -1, 32 },			/* A55 */
+	{ 57, -1, 32 },			/* A56 */
+	{ 58, -1, 32 },			/* A57 */
+	{ 59, -1, 32 },			/* A58 */
+	{ 60, -1, 32 },			/* A59 */
+	{ 61, -1, 32 },			/* A60 */
+	{ 62, -1, 32 },			/* A61 */
+	{ 63, -1, 32 },			/* A62 */
+	{ 64, -1, 32 },			/* A63 */
+	{ 65, 0x58, 32 },		/* lbeg */
+	{ 66, 0x5c, 32 },		/* lend */
+	{ 67, 0x60, 32 },		/* lcount */
+	{ 68, 0x48, 32 },		/* SAR */
+	{ 69, -1, 32 },			/* windowbase */
+	{ 70, -1, 32 },			/* windowstart */
+	{ 71, -1, 32 },			/* configid0 */
+	{ 72, -1, 32 },			/* configid1 */
+	{ 73, 0x04, 32 },		/* PS */
+	{ 74, -1, 32 },			/* threadptr */
+	{ 75, -1, 32 },			/* br */
+	{ 76, 0x54, 32 },		/* scompare1 */
+	{ 77, -1, 32 },			/* acclo */
+	{ 78, -1, 32 },			/* acchi */
+	{ 79, -1, 32 },			/* m0 */
+	{ 80, -1, 32 },			/* m1 */
+	{ 81, -1, 32 },			/* m2 */
+	{ 82, -1, 32 },			/* m3 */
+	{ 83, -1, 32 },			/* expstate */
+	{ 84, -1, 32 },			/* f64r_lo */
+	{ 85, -1, 32 },			/* f64r_hi */
+	{ 86, -1, 32 },			/* f64s */
+	{ 87, -1, 32 },			/* f0 */
+	{ 88, -1, 32 },			/* f1 */
+	{ 89, -1, 32 },			/* f2 */
+	{ 90, -1, 32 },			/* f3 */
+	{ 91, -1, 32 },			/* f4 */
+	{ 92, -1, 32 },			/* f5 */
+	{ 93, -1, 32 },			/* f6 */
+	{ 94, -1, 32 },			/* f7 */
+	{ 95, -1, 32 },			/* f8 */
+	{ 96, -1, 32 },			/* f9 */
+	{ 97, -1, 32 },			/* f10 */
+	{ 98, -1, 32 },			/* f11 */
+	{ 99, -1, 32 },			/* f12 */
+	{ 100, -1, 32 },		/* f13 */
+	{ 101, -1, 32 },		/* f14 */
+	{ 102, -1, 32 },		/* f15 */
+	{ 103, -1, 32 },		/* fcr */
+	{ 104, -1, 32 },		/* fsr */
 };
 
-const struct rtos_register_stacking nuttx_riscv_stacking = {
-	.stack_registers_size = 33 * 4,
+const struct rtos_register_stacking nuttx_esp32_stacking = {
+	.stack_registers_size = 26 * 4,
 	.stack_growth_direction = -1,
-	.num_output_registers = 33,
+	.num_output_registers = ARRAY_SIZE(nuttx_stack_offsets_esp32),
 	.calculate_process_stack = rtos_generic_stack_align8,
-	.register_offsets = nuttx_stack_offsets_riscv,
+	.register_offsets = nuttx_stack_offsets_esp32,
+	.custom_stack_read_fn = nuttx_esp_xtensa_stack_read,
 };
+
+static const struct stack_register_offset nuttx_stack_offsets_esp32s2[] = {
+	{ 0, 0x00, 32 },		/* PC */
+	{ 1, 0x08, 32 },		/* A0 */
+	{ 2, 0x0c, 32 },		/* A1 */
+	{ 3, 0x10, 32 },		/* A2 */
+	{ 4, 0x14, 32 },		/* A3 */
+	{ 5, 0x18, 32 },		/* A4 */
+	{ 6, 0x1c, 32 },		/* A5 */
+	{ 7, 0x20, 32 },		/* A6 */
+	{ 8, 0x24, 32 },		/* A7 */
+	{ 9, 0x28, 32 },		/* A8 */
+	{ 10, 0x2c, 32 },		/* A9 */
+	{ 11, 0x30, 32 },		/* A10 */
+	{ 12, 0x34, 32 },		/* A11 */
+	{ 13, 0x38, 32 },		/* A12 */
+	{ 14, 0x3c, 32 },		/* A13 */
+	{ 15, 0x40, 32 },		/* A14 */
+	{ 16, 0x44, 32 },		/* A15 */
+	/* A16-A63 aren't in the stack frame because they've been flushed to the stack earlier */
+	{ 17, -1, 32 },			/* A16 */
+	{ 18, -1, 32 },			/* A17 */
+	{ 19, -1, 32 },			/* A18 */
+	{ 20, -1, 32 },			/* A19 */
+	{ 21, -1, 32 },			/* A20 */
+	{ 22, -1, 32 },			/* A21 */
+	{ 23, -1, 32 },			/* A22 */
+	{ 24, -1, 32 },			/* A23 */
+	{ 25, -1, 32 },			/* A24 */
+	{ 26, -1, 32 },			/* A25 */
+	{ 27, -1, 32 },			/* A26 */
+	{ 28, -1, 32 },			/* A27 */
+	{ 29, -1, 32 },			/* A28 */
+	{ 30, -1, 32 },			/* A29 */
+	{ 31, -1, 32 },			/* A30 */
+	{ 32, -1, 32 },			/* A31 */
+	{ 33, -1, 32 },			/* A32 */
+	{ 34, -1, 32 },			/* A33 */
+	{ 35, -1, 32 },			/* A34 */
+	{ 36, -1, 32 },			/* A35 */
+	{ 37, -1, 32 },			/* A36 */
+	{ 38, -1, 32 },			/* A37 */
+	{ 39, -1, 32 },			/* A38 */
+	{ 40, -1, 32 },			/* A39 */
+	{ 41, -1, 32 },			/* A40 */
+	{ 42, -1, 32 },			/* A41 */
+	{ 43, -1, 32 },			/* A42 */
+	{ 44, -1, 32 },			/* A43 */
+	{ 45, -1, 32 },			/* A44 */
+	{ 46, -1, 32 },			/* A45 */
+	{ 47, -1, 32 },			/* A46 */
+	{ 48, -1, 32 },			/* A47 */
+	{ 49, -1, 32 },			/* A48 */
+	{ 50, -1, 32 },			/* A49 */
+	{ 51, -1, 32 },			/* A50 */
+	{ 52, -1, 32 },			/* A51 */
+	{ 53, -1, 32 },			/* A52 */
+	{ 54, -1, 32 },			/* A53 */
+	{ 55, -1, 32 },			/* A54 */
+	{ 56, -1, 32 },			/* A55 */
+	{ 57, -1, 32 },			/* A56 */
+	{ 58, -1, 32 },			/* A57 */
+	{ 59, -1, 32 },			/* A58 */
+	{ 60, -1, 32 },			/* A59 */
+	{ 61, -1, 32 },			/* A60 */
+	{ 62, -1, 32 },			/* A61 */
+	{ 63, -1, 32 },			/* A62 */
+	{ 64, -1, 32 },			/* A63 */
+	{ 65, 0x48, 32 },		/* SAR */
+	{ 66, -1, 32 },			/* windowbase */
+	{ 67, -1, 32 },			/* windowstart */
+	{ 68, -1, 32 },			/* configid0 */
+	{ 69, -1, 32 },			/* configid1 */
+	{ 70, 0x04, 32 },		/* PS */
+	{ 71, -1, 32 },			/* threadptr */
+	{ 72, -1, 32 },			/* gpio_out */
+};
+
+const struct rtos_register_stacking nuttx_esp32s2_stacking = {
+	.stack_registers_size = 25 * 4,
+	.stack_growth_direction = -1,
+	.num_output_registers = ARRAY_SIZE(nuttx_stack_offsets_esp32s2),
+	.calculate_process_stack = rtos_generic_stack_align8,
+	.register_offsets = nuttx_stack_offsets_esp32s2,
+	.custom_stack_read_fn = nuttx_esp_xtensa_stack_read,
+};
+
+static const struct stack_register_offset nuttx_stack_offsets_esp32s3[] = {
+	{ 0, 0x00, 32 },		/* PC */
+	{ 1, 0x08, 32 },		/* A0 */
+	{ 2, 0x0c, 32 },		/* A1 */
+	{ 3, 0x10, 32 },		/* A2 */
+	{ 4, 0x14, 32 },		/* A3 */
+	{ 5, 0x18, 32 },		/* A4 */
+	{ 6, 0x1c, 32 },		/* A5 */
+	{ 7, 0x20, 32 },		/* A6 */
+	{ 8, 0x24, 32 },		/* A7 */
+	{ 9, 0x28, 32 },		/* A8 */
+	{ 10, 0x2c, 32 },		/* A9 */
+	{ 11, 0x30, 32 },		/* A10 */
+	{ 12, 0x34, 32 },		/* A11 */
+	{ 13, 0x38, 32 },		/* A12 */
+	{ 14, 0x3c, 32 },		/* A13 */
+	{ 15, 0x40, 32 },		/* A14 */
+	{ 16, 0x44, 32 },		/* A15 */
+	/* A16-A63 aren't in the stack frame because they've been flushed to the stack earlier */
+	{ 17, -1, 32 },			/* A16 */
+	{ 18, -1, 32 },			/* A17 */
+	{ 19, -1, 32 },			/* A18 */
+	{ 20, -1, 32 },			/* A19 */
+	{ 21, -1, 32 },			/* A20 */
+	{ 22, -1, 32 },			/* A21 */
+	{ 23, -1, 32 },			/* A22 */
+	{ 24, -1, 32 },			/* A23 */
+	{ 25, -1, 32 },			/* A24 */
+	{ 26, -1, 32 },			/* A25 */
+	{ 27, -1, 32 },			/* A26 */
+	{ 28, -1, 32 },			/* A27 */
+	{ 29, -1, 32 },			/* A28 */
+	{ 30, -1, 32 },			/* A29 */
+	{ 31, -1, 32 },			/* A30 */
+	{ 32, -1, 32 },			/* A31 */
+	{ 33, -1, 32 },			/* A32 */
+	{ 34, -1, 32 },			/* A33 */
+	{ 35, -1, 32 },			/* A34 */
+	{ 36, -1, 32 },			/* A35 */
+	{ 37, -1, 32 },			/* A36 */
+	{ 38, -1, 32 },			/* A37 */
+	{ 39, -1, 32 },			/* A38 */
+	{ 40, -1, 32 },			/* A39 */
+	{ 41, -1, 32 },			/* A40 */
+	{ 42, -1, 32 },			/* A41 */
+	{ 43, -1, 32 },			/* A42 */
+	{ 44, -1, 32 },			/* A43 */
+	{ 45, -1, 32 },			/* A44 */
+	{ 46, -1, 32 },			/* A45 */
+	{ 47, -1, 32 },			/* A46 */
+	{ 48, -1, 32 },			/* A47 */
+	{ 49, -1, 32 },			/* A48 */
+	{ 50, -1, 32 },			/* A49 */
+	{ 51, -1, 32 },			/* A50 */
+	{ 52, -1, 32 },			/* A51 */
+	{ 53, -1, 32 },			/* A52 */
+	{ 54, -1, 32 },			/* A53 */
+	{ 55, -1, 32 },			/* A54 */
+	{ 56, -1, 32 },			/* A55 */
+	{ 57, -1, 32 },			/* A56 */
+	{ 58, -1, 32 },			/* A57 */
+	{ 59, -1, 32 },			/* A58 */
+	{ 60, -1, 32 },			/* A59 */
+	{ 61, -1, 32 },			/* A60 */
+	{ 62, -1, 32 },			/* A61 */
+	{ 63, -1, 32 },			/* A62 */
+	{ 64, -1, 32 },			/* A63 */
+	{ 65, 0x58, 32 },		/* lbeg */
+	{ 66, 0x5c, 32 },		/* lend */
+	{ 67, 0x60, 32 },		/* lcount */
+	{ 68, 0x48, 32 },		/* SAR */
+	{ 69, -1, 32 },			/* windowbase */
+	{ 70, -1, 32 },			/* windowstart */
+	{ 71, -1, 32 },			/* configid0 */
+	{ 72, -1, 32 },			/* configid1 */
+	{ 73, 0x04, 32 },		/* PS */
+	{ 74, -1, 32 },			/* threadptr */
+	{ 75, -1, 32 },			/* br */
+	{ 76, 0x54, 32 },		/* scompare1 */
+	{ 77, -1, 32 },			/* acclo */
+	{ 78, -1, 32 },			/* acchi */
+	{ 79, -1, 32 },			/* m0 */
+	{ 80, -1, 32 },			/* m1 */
+	{ 81, -1, 32 },			/* m2 */
+	{ 82, -1, 32 },			/* m3 */
+	{ 83, -1, 32 },			/* gpio_out */
+	{ 84, -1, 32 },			/* f0 */
+	{ 85, -1, 32 },			/* f1 */
+	{ 86, -1, 32 },			/* f2 */
+	{ 87, -1, 32 },			/* f3 */
+	{ 88, -1, 32 },			/* f4 */
+	{ 89, -1, 32 },			/* f5 */
+	{ 90, -1, 32 },			/* f6 */
+	{ 91, -1, 32 },			/* f7 */
+	{ 92, -1, 32 },			/* f8 */
+	{ 93, -1, 32 },			/* f9 */
+	{ 94, -1, 32 },			/* f10 */
+	{ 95, -1, 32 },			/* f11 */
+	{ 96, -1, 32 },			/* f12 */
+	{ 97, -1, 32 },			/* f13 */
+	{ 98, -1, 32 },			/* f14 */
+	{ 99, -1, 32 },			/* f15 */
+	{ 100, -1, 32 },		/* fcr */
+	{ 101, -1, 32 },		/* fsr */
+	{ 102, -1, 32 },		/* accx_0 */
+	{ 103, -1, 32 },		/* accx_1 */
+	{ 104, -1, 32 },		/* qacc_h_0 */
+	{ 105, -1, 32 },		/* qacc_h_1 */
+	{ 106, -1, 32 },		/* qacc_h_2 */
+	{ 107, -1, 32 },		/* qacc_h_3 */
+	{ 108, -1, 32 },		/* qacc_h_4 */
+	{ 109, -1, 32 },		/* qacc_l_0 */
+	{ 110, -1, 32 },		/* qacc_l_1 */
+	{ 111, -1, 32 },		/* qacc_l_2 */
+	{ 112, -1, 32 },		/* qacc_l_3 */
+	{ 113, -1, 32 },		/* qacc_l_4 */
+	{ 114, -1, 32 },		/* sar_byte */
+	{ 115, -1, 32 },		/* fft_bit_width */
+	{ 116, -1, 32 },		/* ua_state_0 */
+	{ 117, -1, 32 },		/* ua_state_1 */
+	{ 118, -1, 32 },		/* ua_state_2 */
+	{ 119, -1, 32 },		/* ua_state_3 */
+	{ 120, -1, 128 },		/* q0 */
+	{ 121, -1, 128 },		/* q1 */
+	{ 122, -1, 128 },		/* q2 */
+	{ 123, -1, 128 },		/* q3 */
+	{ 124, -1, 128 },		/* q4 */
+	{ 125, -1, 128 },		/* q5 */
+	{ 126, -1, 128 },		/* q6 */
+	{ 127, -1, 128 },		/* q7 */
+};
+
+const struct rtos_register_stacking nuttx_esp32s3_stacking = {
+	.stack_registers_size = 26 * 4,
+	.stack_growth_direction = -1,
+	.num_output_registers = ARRAY_SIZE(nuttx_stack_offsets_esp32s3),
+	.calculate_process_stack = rtos_generic_stack_align8,
+	.register_offsets = nuttx_stack_offsets_esp32s3,
+	.custom_stack_read_fn = nuttx_esp_xtensa_stack_read,
+};
+
+static int nuttx_esp_xtensa_stack_read(struct target *target,
+	int64_t stack_ptr, const struct rtos_register_stacking *stacking,
+	uint8_t *stack_data)
+{
+	int retval = target_read_buffer(target, stack_ptr, stacking->stack_registers_size,
+		stack_data);
+	if (retval != ERROR_OK)
+		return retval;
+
+	stack_data[4] &= ~0x10;	/* Clear exception bit in PS */
+
+	return ERROR_OK;
+}

--- a/src/rtos/rtos_nuttx_stackings.h
+++ b/src/rtos/rtos_nuttx_stackings.h
@@ -15,5 +15,6 @@
 
 extern const struct rtos_register_stacking nuttx_stacking_cortex_m;
 extern const struct rtos_register_stacking nuttx_stacking_cortex_m_fpu;
+extern const struct rtos_register_stacking nuttx_riscv_stacking;
 
 #endif	/* INCLUDED_RTOS_NUTTX_STACKINGS_H */

--- a/src/rtos/rtos_nuttx_stackings.h
+++ b/src/rtos/rtos_nuttx_stackings.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/***************************************************************************
+ *   Copyright (C) 2020 Espressif Systems Ltd.                             *
+ ***************************************************************************/
+
+#ifndef INCLUDED_RTOS_NUTTX_STACKINGS_H
+#define INCLUDED_RTOS_NUTTX_STACKINGS_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <rtos/rtos.h>
+
+extern const struct rtos_register_stacking nuttx_stacking_cortex_m;
+extern const struct rtos_register_stacking nuttx_stacking_cortex_m_fpu;
+
+#endif	/* INCLUDED_RTOS_NUTTX_STACKINGS_H */

--- a/src/rtos/rtos_nuttx_stackings.h
+++ b/src/rtos/rtos_nuttx_stackings.h
@@ -15,6 +15,8 @@
 
 extern const struct rtos_register_stacking nuttx_stacking_cortex_m;
 extern const struct rtos_register_stacking nuttx_stacking_cortex_m_fpu;
-extern const struct rtos_register_stacking nuttx_riscv_stacking;
+extern const struct rtos_register_stacking nuttx_esp32_stacking;
+extern const struct rtos_register_stacking nuttx_esp32s2_stacking;
+extern const struct rtos_register_stacking nuttx_esp32s3_stacking;
 
 #endif	/* INCLUDED_RTOS_NUTTX_STACKINGS_H */


### PR DESCRIPTION
This PR is created to make internal discussion and tests before pushing a patch to the mainline. 

It looks like our RiscV implementation has some conflicts with riscv-openocd repo. Starting with Xtensa chips might be easier to finalize.